### PR TITLE
채용공고 상태값이 정상적으로 전달되도록 버그 수정

### DIFF
--- a/src/main/java/recruitment/domain/Job.java
+++ b/src/main/java/recruitment/domain/Job.java
@@ -9,7 +9,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import lombok.Builder;
@@ -81,18 +80,11 @@ public class Job {
     }
 
     public JobResponse convertToJobResponse() {
-        List<Long> jobIdList = new ArrayList<>();
-        List<Job> companyJobs = this.company.getJobs();
-        if (companyJobs == null) {
-            companyJobs = new ArrayList<>();
-        }
-        companyJobs.forEach(job -> {
-            Long jobId = job.getId();
-            if (Objects.equals(jobId, this.id)) {
-                return;
-            }
-            jobIdList.add(job.getId());
-        });
+        List<Long> jobIdList = this.company.getJobs()
+                .stream()
+                .map(Job::getId)
+                .filter(jobId -> !Objects.equals(jobId, this.id))
+                .toList();
 
         return JobResponse.builder()
                 .id(this.id)
@@ -104,6 +96,7 @@ public class Job {
                 .stack(this.stack)
                 .description(this.description)
                 .otherJobIdsOfCompany(jobIdList)
+                .status(this.status)
                 .build();
     }
 
@@ -116,6 +109,7 @@ public class Job {
                 .position(this.position)
                 .bounty(this.bounty)
                 .stack(this.stack)
+                .status(this.status)
                 .build();
     }
 

--- a/src/main/java/recruitment/dto/JobRequest.java
+++ b/src/main/java/recruitment/dto/JobRequest.java
@@ -3,6 +3,7 @@ package recruitment.dto;
 import java.beans.ConstructorProperties;
 import lombok.Builder;
 import lombok.Getter;
+import recruitment.domain.Status;
 
 @Getter
 public class JobRequest {
@@ -17,15 +18,18 @@ public class JobRequest {
 
     private final String description;
 
+    private final Status status;
+
     @Builder
-    @ConstructorProperties({"company-id", "position", "bounty", "stack", "description"})
+    @ConstructorProperties({"company-id", "position", "bounty", "stack", "description", "status"})
     public JobRequest(final Long companyId, final String position, final Long bounty, final String stack,
-                      final String description) {
+                      final String description, final Status status) {
         this.companyId = companyId;
         this.position = position;
         this.bounty = bounty;
         this.stack = stack;
         this.description = description;
+        this.status = status;
     }
 
 }

--- a/src/main/java/recruitment/dto/JobResponse.java
+++ b/src/main/java/recruitment/dto/JobResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+import recruitment.domain.Status;
 
 @Getter
 public class JobResponse {
@@ -35,10 +36,13 @@ public class JobResponse {
     @JsonProperty("회사가_올린_다른_채용공고")
     private final List<Long> otherJobIdsOfCompany;
 
+    @JsonProperty("상태")
+    private final Status status;
+
     @Builder
     public JobResponse(final Long id, final String companyName, final String country, final String region,
-                       final String position, final long bounty, final String stack, String description,
-                       List<Long> otherJobIdsOfCompany) {
+                       final String position, final long bounty, final String stack, final String description,
+                       final List<Long> otherJobIdsOfCompany, final Status status) {
         this.id = id;
         this.companyName = companyName;
         this.country = country;
@@ -48,6 +52,7 @@ public class JobResponse {
         this.stack = stack;
         this.description = description;
         this.otherJobIdsOfCompany = otherJobIdsOfCompany;
+        this.status = status;
     }
 
 }

--- a/src/main/java/recruitment/service/JobService.java
+++ b/src/main/java/recruitment/service/JobService.java
@@ -66,8 +66,9 @@ public class JobService {
                 .company(foundJob.getCompany())
                 .position(jobRequestToBeUpdated.getPosition())
                 .bounty(jobRequestToBeUpdated.getBounty())
-                .description(jobRequestToBeUpdated.getDescription())
                 .stack(jobRequestToBeUpdated.getStack())
+                .description(jobRequestToBeUpdated.getDescription())
+                .status(jobRequestToBeUpdated.getStatus())
                 .build();
 
         Job uploadedJob = jobRepository.save(jobToBeUpdated);
@@ -162,11 +163,16 @@ public class JobService {
         if (stack == null) {
             stack = foundJob.getStack();
         }
+        Status status = jobRequest.getStatus();
+        if (status == null) {
+            status = foundJob.getStatus();
+        }
         return JobRequest.builder()
                 .position(position)
                 .bounty(bounty)
                 .description(description)
                 .stack(stack)
+                .status(status)
                 .build();
     }
 

--- a/src/test/java/recruitment/RecruitmentApplicationTests.java
+++ b/src/test/java/recruitment/RecruitmentApplicationTests.java
@@ -1,6 +1,5 @@
 package recruitment;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -71,6 +70,7 @@ class RecruitmentApplicationTests {
         ).andReturn();
         String rawJsonString = mvcResult.getResponse().getContentAsString(Charset.defaultCharset());
         JSONArray jsonArray = new JSONArray(rawJsonString);
+
         System.out.println("수정 전");
         System.out.println(jsonArray.toString(2));
         System.out.println();
@@ -81,7 +81,8 @@ class RecruitmentApplicationTests {
         ).andReturn();
         rawJsonString = mvcResult.getResponse().getContentAsString(Charset.defaultCharset());
         JSONObject jsonAfter1stModify = new JSONObject(rawJsonString);
-        System.out.println("1차 수정 후: 채용보상금 변경");
+
+        System.out.println("1차 수정 후: 채용보상금 변경(500000 -> 1000000)");
         System.out.println(jsonAfter1stModify.toString(2));
         System.out.println();
 
@@ -91,7 +92,8 @@ class RecruitmentApplicationTests {
         ).andReturn();
         rawJsonString = mvcResult.getResponse().getContentAsString(Charset.defaultCharset());
         JSONObject jsonAfter2ndModify = new JSONObject(rawJsonString);
-        System.out.println("2차 수정 후: 사용기술 변경");
+
+        System.out.println("2차 수정 후: 사용기술 변경(javascript -> react)");
         System.out.println(jsonAfter2ndModify.toString(2));
     }
 
@@ -101,31 +103,25 @@ class RecruitmentApplicationTests {
         String idOfJobForWantedAsString = "1";
         String keyword = "원티드코리아";
         MvcResult mvcResult;
+
         mvcResult = mockMvc.perform(
                 get("/jobs/search")
                         .param("keyword", keyword)
         ).andReturn();
-        String rawJsonString = mvcResult.getResponse().getContentAsString(Charset.defaultCharset());
-        JSONArray jsonArray = new JSONArray(rawJsonString);
+        String rawJsonStringBeforeDelete = mvcResult.getResponse().getContentAsString(Charset.defaultCharset());
+        JSONArray jsonArray = new JSONArray(rawJsonStringBeforeDelete);
         System.out.println("삭제 전");
         System.out.println(jsonArray.toString(2));
         System.out.println();
 
         mvcResult = mockMvc.perform(
-                delete("/jobs/" + idOfJobForWantedAsString)
+                post("/jobs/" + idOfJobForWantedAsString)
         ).andReturn();
-        System.out.println("삭제 실행");
-        System.out.println(mvcResult.getResponse().getContentAsString());
-        System.out.println();
-
-        mvcResult = mockMvc.perform(
-                get("/jobs/search")
-                        .param("keyword", keyword)
-        ).andReturn();
-        rawJsonString = mvcResult.getResponse().getContentAsString(Charset.defaultCharset());
-        jsonArray = new JSONArray(rawJsonString);
+        String rawJsonString = mvcResult.getResponse().getContentAsString(Charset.defaultCharset());
+        JSONObject json = new JSONObject(rawJsonString);
         System.out.println("삭제 후");
-        System.out.println(jsonArray.toString(2));
+        System.out.println(json.toString(2));
+        System.out.println();
     }
 
     @DisplayName("4-1. 사용자는 채용공고 목록을 아래와 같이 확인할 수 있습니다.")
@@ -144,42 +140,26 @@ class RecruitmentApplicationTests {
     @DisplayName("4-2. 채용공고 검색 기능 구현")
     @Test
     void functionalRequirementsTest4_2() throws Exception {
-        String idOfWantedLabAsString = "1";
-        System.out.println("키워드-원티드로 검색");
+        String keyword = "네이버";
 
-        MvcResult mvcResult;
-        mvcResult = mockMvc.perform(
-                post("/jobs")
-                        .param("company-id", idOfWantedLabAsString)
-                        .param("position", "백엔드 주니어 개발자")
-                        .param("bounty", "1000000")
-                        .param("stack", "Python")
-                        .param("description", "원티드랩에서 백엔드 주니어 개발자를 채용합니다. 자격요건은..")
-        ).andReturn();
-
-        String rawJsonString = mvcResult.getResponse().getContentAsString(Charset.defaultCharset());
-        JSONObject jsonObject = new JSONObject(rawJsonString);
-        System.out.println("원티드랩 공고 추가");
-        System.out.println(jsonObject.toString(2));
-        System.out.println();
-
-        mvcResult = mockMvc.perform(
+        MvcResult mvcResult = mockMvc.perform(
                 get("/jobs/search")
-                        .param("keyword", "원티드")
+                        .param("keyword", keyword)
         ).andReturn();
+
         String rawJsonArrayString = mvcResult.getResponse().getContentAsString(Charset.defaultCharset());
         JSONArray jsonArray = new JSONArray(rawJsonArrayString);
-        System.out.println("키워드-원티드로 검색");
+        System.out.println("키워드-네이버로 검색");
         System.out.println(jsonArray.toString(2));
     }
 
     @DisplayName("5. 채용 상세 페이지를 가져옵니다.")
     @Test
     void functionalRequirementsTest5() throws Exception {
-        String idOfJobForWanted = "1";
+        String idOfJobForNaver = "2";
         MvcResult mvcResult;
         mvcResult = mockMvc.perform(
-                get("/jobs/detail/" + idOfJobForWanted)
+                get("/jobs/detail/" + idOfJobForNaver)
         ).andReturn();
         String rawJsonArrayString = mvcResult.getResponse().getContentAsString(Charset.defaultCharset());
         JSONObject jsonObject = new JSONObject(rawJsonArrayString);

--- a/src/test/java/recruitment/service/JobServiceTest.java
+++ b/src/test/java/recruitment/service/JobServiceTest.java
@@ -35,6 +35,94 @@ class JobServiceTest {
     @Autowired
     private JobRepository jobRepository;
 
+    @DisplayName("채용공고 추가 기능 테스트")
+    @Test
+    void createJobTest() throws JsonProcessingException {
+        Long companyIdForNaver = 3L;
+        JobRequest jobRequest = JobRequest.builder()
+                .companyId(companyIdForNaver)
+                .position("머신러닝 주니어 개발자")
+                .bounty(500_000L)
+                .stack("tensorflow")
+                .description("네이버에서 머신러닝 주니어 개발자를 채용합니다. 필수사항 - 텐서플로우")
+                .build();
+        Job createdJob = jobService.create(jobRequest);
+        Optional<Job> mayBeFoundJob = jobRepository.findById(createdJob.getId());
+        assert mayBeFoundJob.isPresent();
+        Job foundJob = mayBeFoundJob.get();
+
+        System.out.println("추가된 채용공고");
+        String foundJobAsString = objectWriter.writeValueAsString(foundJob);
+        System.out.println(foundJobAsString);
+
+        Assertions
+                .assertThat(createdJob)
+                .isEqualTo(foundJob);
+    }
+
+    @DisplayName(value = "채용공고 수정 기능 테스트")
+    @Test
+    void updateTest() throws JsonProcessingException {
+        Long jobId = 1L;
+        Optional<Job> mayBeFoundJobBeforeUpdate = jobRepository.findById(jobId);
+        assert mayBeFoundJobBeforeUpdate.isPresent();
+        Job jobBeforeUpdate = mayBeFoundJobBeforeUpdate.get();
+
+        String jobBeforeUpdateAsString = objectWriter.writeValueAsString(jobBeforeUpdate);
+        System.out.println("수정 전 채용 공고");
+        System.out.println(jobBeforeUpdateAsString);
+        System.out.println();
+
+        String stackToBeUpdated = "react";
+        String descriptionToBeUpdated = "원티드코리아에서 리액트 프론트엔드 개발자를 채용합니다.";
+        JobRequest jobUpdateRequest = JobRequest.builder()
+                .stack(stackToBeUpdated)
+                .description(descriptionToBeUpdated)
+                .build();
+        Job jobAfterUpdate = jobService.update(jobId, jobUpdateRequest);
+
+        String jobAfterUpdateAsString = objectWriter.writeValueAsString(jobAfterUpdate);
+        System.out.println("수정 후 채용 공고: 사용기술, 채용내용 변경");
+        System.out.println(jobAfterUpdateAsString);
+        System.out.println();
+
+        Assertions
+                .assertThat(jobBeforeUpdate.getId())
+                .isEqualTo(jobAfterUpdate.getId());
+        Assertions
+                .assertThat(jobBeforeUpdate.getCompany())
+                .isEqualTo(jobAfterUpdate.getCompany());
+        Assertions
+                .assertThat(jobBeforeUpdate.getPosition())
+                .isEqualTo(jobAfterUpdate.getPosition());
+        Assertions
+                .assertThat(jobBeforeUpdate.getBounty())
+                .isEqualTo(jobAfterUpdate.getBounty());
+        Assertions
+                .assertThat(stackToBeUpdated)
+                .isEqualTo(jobAfterUpdate.getStack());
+        Assertions
+                .assertThat(descriptionToBeUpdated)
+                .isEqualTo(jobAfterUpdate.getDescription());
+        Assertions
+                .assertThat(jobBeforeUpdate.getStatus())
+                .isEqualTo(jobAfterUpdate.getStatus());
+    }
+
+    @DisplayName("채용공고 삭제 기능 테스트")
+    @Test
+    void softDeleteTest() {
+        long jobId = 1L;
+        jobService.softDelete(jobId);
+
+        Optional<Job> mayBeFoundJob = jobRepository.findById(jobId);
+        assert mayBeFoundJob.isPresent();
+        Job foundJob = mayBeFoundJob.get();
+        Assertions
+                .assertThat(foundJob.getStatus())
+                .isEqualTo(Status.CLOSE);
+    }
+
     @DisplayName("모든 채용공고 조회 기능 테스트")
     @Test
     void findAllJobsTest() throws JsonProcessingException {
@@ -48,30 +136,11 @@ class JobServiceTest {
                 .isEqualTo(4);
     }
 
-    @DisplayName("채용공고 추가 기능 테스트")
-    @Test
-    void createJobTest() {
-        Long companyIdForNaver = 3L;
-        JobRequest jobRequest = JobRequest.builder()
-                .companyId(companyIdForNaver)
-                .position("머신러닝 주니어 개발자")
-                .bounty(500_000L)
-                .stack("tensorflow")
-                .description("네이버에서 머신러닝 주니어 개발자를 채용합니다. 필수사항 - 텐서플로우")
-                .build();
-        Job createdJob = jobService.create(jobRequest);
-        Optional<Job> mayBeFoundJob = jobRepository.findById(createdJob.getId());
-        assert mayBeFoundJob.isPresent();
-        Job foundJob = mayBeFoundJob.get();
-        Assertions
-                .assertThat(createdJob)
-                .isEqualTo(foundJob);
-    }
-
     @DisplayName("채용공고 검색 기능 테스트")
     @Test
-    void searchJobTest() throws JsonProcessingException {
-        List<JobSimpleResponse> foundJobs = jobService.search("네이버");
+    void searchTest() throws JsonProcessingException {
+        String keyword = "네이버";
+        List<JobSimpleResponse> foundJobs = jobService.search(keyword);
         String foundJobsAsString = objectWriter.writeValueAsString(foundJobs);
         System.out.println(foundJobsAsString);
         Assertions
@@ -82,24 +151,10 @@ class JobServiceTest {
     @DisplayName("상세 채용공고 조회 기능 테스트")
     @Test
     void getJobDetailTest() throws JsonProcessingException {
-        long jobId = 1L;
+        long jobId = 2L;
         JobResponse jobDetail = jobService.getDetail(jobId);
         String jobDetailAsString = objectWriter.writeValueAsString(jobDetail);
         System.out.println(jobDetailAsString);
-    }
-
-    @DisplayName("채용공고 삭제 기능 테스트")
-    @Test
-    void softDeleteJobByIdTest() {
-        long jobId = 1L;
-        jobService.softDelete(jobId);
-
-        Optional<Job> mayBeFoundJob = jobRepository.findById(jobId);
-        assert mayBeFoundJob.isPresent();
-        Job foundJob = mayBeFoundJob.get();
-        Assertions
-                .assertThat(foundJob.getStatus())
-                .isEqualTo(Status.CLOSE);
     }
 
     @DisplayName(value = "채용공고에 지원하는 기능 테스트")
@@ -111,7 +166,6 @@ class JobServiceTest {
 
         Optional<Job> mayBeFoundJob = jobRepository.findById(jobId);
         assert mayBeFoundJob.isPresent();
-        Job foundJob = mayBeFoundJob.get();
         ApplicationResponse createdApplication = jobService.apply(jobId, username);
 
         Assertions


### PR DESCRIPTION
### 작업한 내용
* 공고 내용을 수정한 뒤 상태값(OPEN/CLOSE)이 유지가 되지 않는 현상 수정
* 모든 공고 목록을 가져왔을 때 상태값이 null인 현상 수정

### 후속 작업
* close #21 